### PR TITLE
fix confusion of mutable array "times" in __init__ of Surrogate

### DIFF
--- a/gwmemory/waveforms/surrogate.py
+++ b/gwmemory/waveforms/surrogate.py
@@ -136,11 +136,11 @@ class Surrogate(MemoryGenerator):
         self.times = times
 
         if times is not None and max(times) < 10:
-            times *= self.t_to_geo
+            times_ = times * self.t_to_geo
 
-        h_lm, times = self.time_domain_oscillatory(modes=modes, times=times)
+        h_lm, times_ = self.time_domain_oscillatory(modes=modes, times=times_)
 
-        MemoryGenerator.__init__(self, name=name, h_lm=h_lm, times=times)
+        MemoryGenerator.__init__(self, name=name, h_lm=h_lm, times=times_)
 
     def time_domain_oscillatory(self, times=None, modes=None, inc=None, phase=None):
         """


### PR DESCRIPTION
I wrote a program for test:


import numpy as np
from gwmemory import time_domain_memory

params = dict(
    model = 'NRSur7dq2',
    times = np.linspace(-0.04, -0.03, 10001),
    q = 1,
    total_mass = 2,
    spin_1 = [0,0,0],
    spin_2 = [0,0,0],
    distance = 15e-3,
    inc = np.pi/2,
    phase = 0,
)

print(time_domain_memory(**params))
print(time_domain_memory(**params))


Everything worked correctly while running the first " print(time_domain_memory(**params) ", However error was raised while running the second one.

I think the reason was that the array "times" was changed in line 139, and since array is mutable object, self.times (defined in line 136) and even " np.linspace(-0.04, -0.03, 10001) " in test program was changed.

If I modify the source code, and use array "times_" to avoid confusion like this, two " print(time_domain_memory(**params)) " will return the same thing, which is also the same with the result of the first " print(time_domain_memory(**params) " when I didn't modify the code. But I am not sure whether the code works correctly after I modify it.

Thank you!
