### PR TITLE
BUGFIX: fix default distance

### DIFF
--- a/gwmemory/angles.py
+++ b/gwmemory/angles.py
@@ -62,7 +62,7 @@ def analytic_gamma(lm1, lm2, ell):
     m2 = -m2
     m3 = m1 + m2
     return (
-        (-1)**(ell1 + ell2 + ell + m3 + m2)
+        (-1.0) ** (ell1 + ell2 + ell + m3 + m2)
         * (2 * ell1 + 1)**0.5 * (2 * ell2 + 1)**0.5 * (2 * ell + 1)**0.5
         * float(wigner_3j(ell1, ell2, ell, s1, s2, -s3) * wigner_3j(ell1, ell2, ell, m1, m2, -m3))
         * np.pi**0.5 / 2
@@ -374,6 +374,11 @@ def load_gamma(data_dir=None):
     gamma_lmlm: dict
         Dictionary of gamma_lmlm.
     """
+    from warnings import warn
+    warn(
+        f"The load_gamma function is deprecated and will be removed in v0.4.0."
+        "Use gwmemory.angles.analytic_gamma to compute the terms on the fly."
+    )
     if data_dir is None:
         data_dir = str(Path(__file__).parent / "data")
     data_files = glob.glob(f"{data_dir}/gamma*.dat")

--- a/gwmemory/waveforms/base.py
+++ b/gwmemory/waveforms/base.py
@@ -16,7 +16,7 @@ class MemoryGenerator(object):
 
     @property
     def distance(self):
-        return getattr(self, "_distance", "None")
+        return getattr(self, "_distance", None)
 
     @distance.setter
     def distance(self, distance):
@@ -38,11 +38,10 @@ class MemoryGenerator(object):
             will be returned.
         phase: float, optional
             Reference phase of the source, if None, the spherical harmonic
-            modes will be returned. For CBCs this is the phase at coalesence.
-        gamma_lmlm: dict
+            modes will be returned. For CBCs this is the phase at coalescence.
+        gamma_lmlm: dict, deprecated
             Dictionary of arrays defining the angular dependence of the
-            different memory modes, default=None if None the function will
-            attempt to load them.
+            different memory modes, these are now computed/cached on the fly.
 
         Return
         ------
@@ -65,7 +64,7 @@ class MemoryGenerator(object):
                     index = (lm, lmp)
                     dhlm_dt_sq[index] = dhlm_dt[lm] * np.conjugate(dhlm_dt[lmp])
                 except KeyError:
-                    None
+                    pass
 
         if gamma_lmlm is None:
             gamma_lmlm = load_gamma()


### PR DESCRIPTION
There's a minor bug introduced in https://github.com/ColmTalbot/gwmemory/pull/14 in some instances. This PR fixes the default value and starts deprecating the use of the lookup tables.